### PR TITLE
fix: fix authz page multiple calls issue

### DIFF
--- a/frontend/src/pages/authz/Authz.js
+++ b/frontend/src/pages/authz/Authz.js
@@ -128,7 +128,7 @@ export default function Authz() {
         })
       );
     }
-  }, [params, chainInfo, txAuthzRes?.status]);
+  }, [chainInfo, txAuthzRes?.status]);
 
   useEffect(() => {
     if (grantsToMe?.errMsg !== "" && grantsToMe?.status === "rejected") {


### PR DESCRIPTION
Closes #640 
Its making multiple calls for Cosmos and Passage network.
`getGrantsToMe` is getting dispatched multiple times due to `params` as dependency in useEffect.
Now I have removed `params` from dependency.