### PR TITLE
feat: Add chains list in NavBar

### DIFF
--- a/frontend/src/components/CustomAppBar.js
+++ b/frontend/src/components/CustomAppBar.js
@@ -7,8 +7,18 @@ import LightModeOutlined from "@mui/icons-material/LightModeOutlined";
 import DarkModeOutlined from "@mui/icons-material/DarkModeOutlined";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
-import { setAuthzMode } from "../features/common/commonSlice";
-import { FormControlLabel, Switch } from "@mui/material";
+import {
+  setAuthzMode,
+  setError,
+  setSelectedNetwork,
+} from "../features/common/commonSlice";
+import {
+  FormControlLabel,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Switch,
+} from "@mui/material";
 import Button from "@mui/material/Button";
 import { getGrantsToMe } from "../features/authz/authzSlice";
 import { resetTabs, resetTabResetStatus } from "../features/authz/authzSlice";
@@ -18,6 +28,8 @@ import { KEY_WALLET_NAME, removeAllFeegrants } from "../utils/localStorage";
 import { resetFeegrantState } from "../features/feegrant/feegrantSlice";
 import { ConnectWalletDialog } from "./wallet/ConnectWallet";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
+import ExpandMoreOutlinedIcon from "@mui/icons-material/ExpandMoreOutlined";
+import { useNavigate } from "react-router-dom";
 
 export const connectWallet = (walletName, dispatch) => {
   if (walletName === "keplr") {
@@ -54,15 +66,29 @@ export const connectWallet = (walletName, dispatch) => {
 export function CustomAppBar(props) {
   const tabResetStatus = useSelector((state) => state.authz.tabResetStatus);
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const networks = useSelector((state) => state.wallet.networks);
   const isAuthzMode = useSelector((state) => state.common.authzMode);
   const isWalletConnected = useSelector((state) => state.wallet.connected);
 
   const [showSelectWallet, setShowSelectWallet] = useState(false);
+  const selectNetwork = useSelector(
+    (state) => state.common.selectedNetwork.chainName
+  );
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const chainIDs = Object.keys(networks);
 
   const switchHandler = (event) => {
     dispatch(setAuthzMode(event.target.checked));
+  };
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const navigateTo = (path) => {
+    navigate(path);
   };
 
   useEffect(() => {
@@ -95,6 +121,15 @@ export function CustomAppBar(props) {
     dispatch(resetWallet());
   };
 
+  const authzModeAlert = () => {
+    dispatch(
+      setError({
+        type: "error",
+        message: "You can't switch networks in Authz Mode",
+      })
+    );
+  };
+
   return (
     <AppBar
       position="absolute"
@@ -110,6 +145,78 @@ export function CustomAppBar(props) {
           src="https://raw.githubusercontent.com/vitwit/chain-registry/08711dbf4cbc12d37618cecd290ad756c07d538b/cosmoshub/images/cosmoshub-logo.png"
           style={{ maxWidth: 161, maxHeight: 45 }}
         />
+        <Button
+          id="demo-positioned-button"
+          color="inherit"
+          endIcon={<ExpandMoreOutlinedIcon />}
+          aria-controls={anchorEl ? "demo-positioned-menu" : undefined}
+          aria-haspopup="true"
+          aria-expanded={anchorEl ? "true" : undefined}
+          onClick={handleClick}
+          sx={{ ml: 2 }}
+        >
+          {selectNetwork || "All Networks"}
+        </Button>
+        <Menu
+          id="demo-positioned-menu"
+          aria-labelledby="demo-positioned-button"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => setAnchorEl(null)}
+          anchorOrigin={{
+            vertical: "top",
+            horizontal: "left",
+          }}
+          transformOrigin={{
+            vertical: "top",
+            horizontal: "left",
+          }}
+        >
+          {chainIDs.map((chain) => (
+            <MenuItem
+              key={chain}
+              onClick={() => {
+                setAnchorEl(null);
+                if (isAuthzMode) {
+                  authzModeAlert();
+                } else {
+                  dispatch(
+                    setSelectedNetwork({
+                      chainName: networks[chain].network.config.chainName,
+                      chainID: networks[chain].network.config.chainId,
+                    })
+                  );
+                  navigateTo(
+                    `${networks[
+                      chain
+                    ].network.config.chainName.toLowerCase()}/overview`
+                  );
+                }
+              }}
+            >
+              <ListItemText>
+                {networks[chain].network.config.chainName}
+              </ListItemText>
+            </MenuItem>
+          ))}
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              if (isAuthzMode) {
+                authzModeAlert();
+              } else {
+                dispatch(
+                  setSelectedNetwork({
+                    chainName: "",
+                  })
+                );
+                navigateTo("/");
+              }
+            }}
+          >
+            <ListItemText>All Networks</ListItemText>
+          </MenuItem>
+        </Menu>
         <Typography
           component="h1"
           variant="h6"
@@ -124,12 +231,7 @@ export function CustomAppBar(props) {
           aria-label="mode"
           onClick={() => props.onModeChange()}
         >
-          {
-            props.darkMode ?
-              <LightModeOutlined />
-              :
-              <DarkModeOutlined />
-          }
+          {props.darkMode ? <LightModeOutlined /> : <DarkModeOutlined />}
         </IconButton>
 
         {isWalletConnected ? (

--- a/frontend/src/components/common/SelectNetwork.jsx
+++ b/frontend/src/components/common/SelectNetwork.jsx
@@ -6,7 +6,6 @@ import { useDispatch } from 'react-redux';
 
 export default function SelectNetwork(props) {
     const { onSelect, networks, defaultNetwork } = props;
-    const dispatch = useDispatch();
 
     const [selected, setSelected] = useState("cosmoshub");
     const handleNetworkSelect = (e) => {

--- a/frontend/src/components/common/SelectNetwork.jsx
+++ b/frontend/src/components/common/SelectNetwork.jsx
@@ -3,7 +3,6 @@ import { MenuItem, Select, FormControl } from '@mui/material'
 import { Box } from '@mui/system'
 import PropTypes from "prop-types";
 import { useDispatch } from 'react-redux';
-import { setSelectedNetwork } from '../../features/common/commonSlice';
 
 export default function SelectNetwork(props) {
     const { onSelect, networks, defaultNetwork } = props;
@@ -20,14 +19,6 @@ export default function SelectNetwork(props) {
             setSelected(defaultNetwork)
         }
     }, [defaultNetwork]);
-
-    useEffect(() => {
-        dispatch(
-            setSelectedNetwork({
-              chainName: selected
-            })
-          );
-    }, [selected])
 
     return (
         <Box sx={{ maxWidth: 150 }}>

--- a/frontend/src/components/common/SelectNetwork.jsx
+++ b/frontend/src/components/common/SelectNetwork.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { MenuItem, Select, FormControl } from '@mui/material'
 import { Box } from '@mui/system'
 import PropTypes from "prop-types";
-import { useDispatch } from 'react-redux';
 
 export default function SelectNetwork(props) {
     const { onSelect, networks, defaultNetwork } = props;

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -6,7 +6,13 @@ import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import ActiveProposals from "./gov/ProposalsPage";
 import StakingPage from "./staking/StakingPage";
-import { Routes, Route, useLocation, useNavigate } from "react-router-dom";
+import {
+  Routes,
+  Route,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 import { CircularProgress } from "@mui/material";
 import Page404 from "./Page404";
 import { useDispatch, useSelector } from "react-redux";
@@ -85,6 +91,7 @@ function a11yProps(index) {
 }
 
 function getTabIndex(path) {
+  console.log("called.......");
   if (path.includes("transfers")) return 1;
   if (path.includes("gov")) return 2;
   else if (path.includes("staking")) return 3;
@@ -100,7 +107,7 @@ export default function Home(props) {
   const authzEnabled = useSelector((state) => state.common.authzMode);
   const [value, setValue] = React.useState(0);
   const selectedNetwork = useSelector(
-    (state) => state.common.selectedNetwork?.chainName || ""
+    (state) => state.common.selectedNetwork?.chainName.toLowerCase() || ""
   );
   const [network, setNetwork] = React.useState(selectedNetwork);
   const networks = useSelector((state) => state.wallet.networks);
@@ -117,10 +124,8 @@ export default function Home(props) {
   const handleChange = (event, newValue) => {
     setValue(newValue);
     if (newValue === 8) {
-      if (selectedNetwork === "") 
-        navigate("/passage/airdrop-check");
-      else
-      navigate(`/${selectedNetwork.toLowerCase()}/airdrop-check`);
+      if (selectedNetwork === "") navigate("/passage/airdrop-check");
+      else navigate(`/${selectedNetwork.toLowerCase()}/airdrop-check`);
     } else if (
       newValue === 0 ||
       newValue === 2 ||
@@ -160,7 +165,7 @@ export default function Home(props) {
 
   useEffect(() => {
     setValue(getTabIndex(page));
-  }, []);
+  }, [selectedNetwork]);
 
   return (
     <Box>
@@ -238,7 +243,7 @@ export default function Home(props) {
             }}
             disabled={authzEnabled && !authzTabs?.groupsEnabled}
           />
-          {!authzEnabled && (
+          {(!authzEnabled && selectedNetwork === "passage" )? (
             <Tab
               label="Airdrop"
               {...a11yProps(8)}
@@ -247,7 +252,7 @@ export default function Home(props) {
                 fontWeight: 600,
               }}
             />
-          )}
+          ):null}
         </Tabs>
       </Box>
 
@@ -341,7 +346,10 @@ export default function Home(props) {
                 path="/:networkName/groups/groups/:groupID/proposals/:id"
                 element={<GroupProposal />}
               />
-              <Route path="/:networkName/airdrop-check" element={<AirdropEligibility />} />
+              <Route
+                path="/:networkName/airdrop-check"
+                element={<AirdropEligibility />}
+              />
 
               <Route path="*" element={<Page404 />}></Route>
             </Routes>


### PR DESCRIPTION
- When network is changed in NavBar, redirect to general overview or chain specific overview page
- Added alert when network changed in Authz Mode
- SelectNetwork present in all pages is independent of navbar SelectNetwork
- Enabled AirDrop only when Passage is selected in navbar