### PR TITLE
chore: remove coloured part in transfers

### DIFF
--- a/frontend/src/app/(routes)/transfers/components/MultiTransfer.tsx
+++ b/frontend/src/app/(routes)/transfers/components/MultiTransfer.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import Messages from './Messages';
-import Summary from './Summary';
 import MultiTxUpload from './MultiTxUpload';
 import { useForm } from 'react-hook-form';
 import { CustomMultiLineTextField } from '@/components/CustomTextField';
@@ -67,9 +66,9 @@ const MultiTransfer = ({ chainID }: { chainID: string }) => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <div className="w-full h-[605px] flex">
         <div className="w-1/2 flex flex-col justify-between pr-5">
-          <div>
+          {/* <div>
             <Summary chainIDs={[chainID]} />
-          </div>
+          </div> */}
           <MultiTxUpload addMsgs={addMsgs} chainID={chainID} />
           <div>
             <div className="text-sm not-italic font-normal leading-[normal] mb-2">

--- a/frontend/src/app/(routes)/transfers/components/SingleTransfer.tsx
+++ b/frontend/src/app/(routes)/transfers/components/SingleTransfer.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import Summary from './Summary';
 import SendPage from '../SendPage';
 
 const SingleTransfer = ({ chainIDs }: { chainIDs: string[] }) => {
   return (
     <div className="w-full h-full space-y-6">
-      <Summary chainIDs={chainIDs} />
+      {/* <Summary chainIDs={chainIDs} /> */}
       <SendPage chainIDs={chainIDs} />
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed unused `Summary` component from multi and single transfer features.
- **Style**
	- Temporarily disabled display of the `Summary` component in the transfer interfaces.
- **New Features**
	- Integrated `SendPage` component with `chainIDs` prop for enhanced transfer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->