### PR TITLE
multisig(fix): remove authtokens

### DIFF
--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -2,7 +2,7 @@ import { DelegationResponse, Params, Validator } from '@/types/staking';
 import { parseBalance } from './denom';
 import { MultisigThresholdPubkey, SinglePubkey } from '@cosmjs/amino';
 import { Options } from '@/custom-hooks/useSortedAssets';
-import { getAuthToken } from './localStorage';
+import { getAuthToken, removeAllAuthTokens } from './localStorage';
 import { MultisigAddressPubkey } from '@/types/multisig';
 
 export const convertPaginationToParams = (
@@ -347,6 +347,9 @@ export const isVerified = ({
   if (token) {
     if (token.address === address && token.chainID === chainID) {
       return true;
+    } else {
+      removeAllAuthTokens();
+      return false;
     }
   }
   return false;


### PR DESCRIPTION
- When user close resolute and switch the account in some other website, auth tokens are still present in localstorage
- Now removing auth token when ever the address in localstorage and current logged-in addresses are different