### PR TITLE
chore: remove dummy text

### DIFF
--- a/frontend/src/app/(routes)/authz/components/DialogCreateAuthzGrant.tsx
+++ b/frontend/src/app/(routes)/authz/components/DialogCreateAuthzGrant.tsx
@@ -383,10 +383,10 @@ const DialogCreateAuthzGrant: React.FC<DialogCreateAuthzGrantProps> = (
                 Create Grant : Step {step}
               </h2>
               {/* TODO: Change the below text content  */}
-              <div className="text-[14px]">
+              {/* <div className="text-[14px]">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </div>
+              </div> */}
             </div>
             <div className="divider-line"></div>
             {step === STEP_ONE ? (


### PR DESCRIPTION
Removed dummy text in create authz dialog box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Temporarily removed a text content section from the authorization dialog for a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->