### PR TITLE
fix: fix loading contracts using code_id in query params

### DIFF
--- a/frontend/src/app/(routes)/cosmwasm/[network]/PageContracts.tsx
+++ b/frontend/src/app/(routes)/cosmwasm/[network]/PageContracts.tsx
@@ -19,12 +19,19 @@ const PageContracts = ({ chainName }: { chainName: string }) => {
   const [selectedTab, setSelectedTab] = useState('Contracts');
 
   const paramContractAddress = useSearchParams().get('contract');
+  const paramsCodeId = useSearchParams().get('code_id');
 
   useEffect(() => {
     if (paramContractAddress?.length) {
       setSelectedTab('Contracts');
     }
   }, [paramContractAddress]);
+
+  useEffect(() => {
+    if (paramsCodeId?.length) {
+      setSelectedTab('All Contracts');
+    }
+  }, [paramsCodeId]);
 
   return (
     <div className="h-screen flex flex-col p-6 px-10 gap-10">

--- a/frontend/src/app/(routes)/cosmwasm/components/AddAddresses.tsx
+++ b/frontend/src/app/(routes)/cosmwasm/components/AddAddresses.tsx
@@ -25,7 +25,7 @@ const AddAddresses = (props: AddAddressesI) => {
     const input = e.target.value;
     const newAddresses = addresses.map((value, key) => {
       if (index === key) {
-        input.trim();
+       return input.trim();
       }
       return value;
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - URL parameter `code_id` now sets the selected tab to 'All Contracts' automatically, enhancing navigation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->